### PR TITLE
feat: ignore buffers that are of the type `nofile`, `prompt`, `terminal`

### DIFF
--- a/lua/highlight-whitespace/core.lua
+++ b/lua/highlight-whitespace/core.lua
@@ -21,21 +21,20 @@ local function is_in_match_groups(gname, wid)
 end
 
 local function two_wins_with_one_buffer_on_tabpage()
-    local wins = vim.api.nvim_tabpage_list_wins(0)
-    local buf_seen = {}
-    for _, win in ipairs(wins) do
-        local buf = vim.api.nvim_win_get_buf(win)
-        if buf_seen[buf] then
-            return true
-        end
-        buf_seen[buf] = true
+  local wins = vim.api.nvim_tabpage_list_wins(0)
+  local buf_seen = {}
+  for _, win in ipairs(wins) do
+    local buf = vim.api.nvim_win_get_buf(win)
+    if buf_seen[buf] then
+      return true
     end
-    return false
+    buf_seen[buf] = true
+  end
+  return false
 end
 
-
-function M.clear_uws_match(bnr)
-  local bnr = bnr or fn.bufnr()
+function M.clear_uws_match(args)
+  local bnr = (args or {}).buf or fn.bufnr()
   local bname = api.nvim_buf_get_name(bnr)
   local wid = fn.bufwinid(bnr)
 
@@ -96,8 +95,8 @@ function M.get_matches_from_cache()
   M.match_uws()
 end
 
-function M.save_matches_to_cache_and_clear(bnr)
-  local bnr = bnr or fn.bufnr()
+function M.save_matches_to_cache_and_clear(args)
+  local bnr = (args or {}).buf or fn.bufnr()
   local bname = api.nvim_buf_get_name(bnr)
   local wid = fn.bufwinid(bnr)
   M.buffer_cached_matches[bname] = fn.getmatches(wid)

--- a/lua/highlight-whitespace/core.lua
+++ b/lua/highlight-whitespace/core.lua
@@ -99,12 +99,15 @@ function M.save_matches_to_cache_and_clear(args)
   local bnr = (args or {}).buf or fn.bufnr()
   local bname = api.nvim_buf_get_name(bnr)
   local wid = fn.bufwinid(bnr)
-  M.buffer_cached_matches[bname] = fn.getmatches(wid)
-  M.win_group_match[bname] = nil
+  local ok, matches = pcall(fn.getmatches, wid)
+  if ok then
+    M.buffer_cached_matches[bname] = matches
+    M.win_group_match[bname] = nil
 
-  --- TODO: maybe add check for non-modifiable buffers?
-  if api.nvim_win_get_config(wid).relative == "" then
-    fn.clearmatches()
+    --- TODO: maybe add check for non-modifiable buffers?
+    if api.nvim_win_get_config(wid).relative == "" then
+      fn.clearmatches()
+    end
   end
 end
 

--- a/lua/highlight-whitespace/core.lua
+++ b/lua/highlight-whitespace/core.lua
@@ -96,19 +96,19 @@ function M.get_matches_from_cache()
 end
 
 function M.save_matches_to_cache_and_clear(args)
-  local bnr = (args or {}).buf or fn.bufnr()
-  local bname = api.nvim_buf_get_name(bnr)
+  local bnr = (args or {}).buf or api.nvim_get_current_buf()
   local wid = fn.bufwinid(bnr)
-  local ok, matches = pcall(fn.getmatches, wid)
-  if ok then
-    M.buffer_cached_matches[bname] = matches
-    M.win_group_match[bname] = nil
 
-    --- TODO: maybe add check for non-modifiable buffers?
-    if api.nvim_win_get_config(wid).relative == "" then
-      fn.clearmatches()
-    end
+  if
+    wid < 0
+    or api.nvim_win_get_config(wid).relative ~= ""
+    or not api.nvim_get_option_value("modifiable", { buf = bnr }) then
+    return
   end
+
+  local bname = api.nvim_buf_get_name(bnr)
+  M.buffer_cached_matches[bname] = fn.getmatches(wid)
+  M.win_group_match[bname] = nil
 end
 
 function M.no_match_cl()

--- a/lua/highlight-whitespace/init.lua
+++ b/lua/highlight-whitespace/init.lua
@@ -1,12 +1,8 @@
 local core = require "highlight-whitespace.core"
+local wrap_fn = require "highlight-whitespace.wrap_fn"
 local utils = require "highlight-whitespace.utils"
 local api = vim.api
 local M = {}
-
-local function is_buf_ignored(buf)
-  local buftype = buf.buftype
-  return buftype == "nofile" or buftype == "prompt" or buftype == "terminal"
-end
 
 function M.setup(cfg)
   core.cfg = vim.tbl_extend("keep", cfg or {}, utils.default)
@@ -20,64 +16,26 @@ function M.setup(cfg)
   end, core.cfg.palette)
 
   local aug_hws = api.nvim_create_augroup("HighlightWS", {})
-  local match_uws_events = { "TextChanged", "CompleteDone" }
-  if core.cfg.clear_on_bufleave then
-    api.nvim_create_autocmd("BufLeave", {
+  local create_autocmd = function(events, callback)
+    api.nvim_create_autocmd(events, {
       callback = function(args)
-        core.clear_uws_match(args.buf)
+        callback(args)
       end,
       group = aug_hws,
     })
+  end
+
+  local match_uws_events = { "TextChanged", "CompleteDone" }
+  if core.cfg.clear_on_bufleave then
+    create_autocmd("BufLeave", core.clear_uws_match)
     table.insert(match_uws_events, "BufEnter")
   end
-  api.nvim_create_autocmd(match_uws_events, {
-    callback = function ()
-      if is_buf_ignored(vim.bo) then
-        return
-      end
-      core.match_uws()
-    end,
-  })
-  api.nvim_create_autocmd("BufWinEnter", {
-    callback = function ()
-      if is_buf_ignored(vim.bo) then
-        return
-      end
-      core.get_matches_from_cache()
-    end,
-    group = aug_hws,
-  })
-  api.nvim_create_autocmd("BufHidden", {
-    callback = function(args)
-      if is_buf_ignored(vim.bo) then
-        return
-      end
-      core.save_matches_to_cache_and_clear(args.buf)
-    end,
-    group = aug_hws,
-  })
-  api.nvim_create_autocmd({ "InsertEnter", "CursorMovedI" }, {
-    callback = function()
-      if is_buf_ignored(vim.bo) then
-        return
-      end
-      core.no_match_cl()
-    end,
-    group = aug_hws,
-  })
-  api.nvim_create_autocmd("InsertLeave", {
-    callback = function ()
-      if is_buf_ignored(vim.bo) then
-        return
-      end
-      core.clear_no_match_cl()
-    end,
-    group = aug_hws,
-  })
-  api.nvim_create_autocmd("QuitPre", {
-    callback = core.prune_dicts,
-    group = aug_hws,
-  })
+  create_autocmd(match_uws_events, wrap_fn.match_uws)
+  create_autocmd("BufWinEnter", wrap_fn.get_matches_from_cache)
+  create_autocmd("BufHidden", wrap_fn.save_matches_to_cache_and_clear)
+  create_autocmd({ "InsertEnter", "CursorMovedI" }, wrap_fn.no_match_cl)
+  create_autocmd("InsertLeave", wrap_fn.clear_no_match_cl)
+  create_autocmd("QuitPre", core.prune_dicts)
   M._set_up = true
 end
 

--- a/lua/highlight-whitespace/wrap_fn.lua
+++ b/lua/highlight-whitespace/wrap_fn.lua
@@ -1,0 +1,29 @@
+local M = {}
+local core = require "highlight-whitespace.core"
+
+local function valid_buftype_callback(fn)
+  return function(args)
+    local buftype = vim.api.nvim_buf_get_option(args.buf, "buftype")
+    if buftype == "nofile" or buftype == "prompt" or buftype == "terminal" then
+      return
+    end
+
+    fn(args)
+  end
+end
+
+local fns_to_wrap = {
+  "match_uws",
+  "get_matches_from_cache",
+  "save_matches_to_cache_and_clear",
+  "no_match_cl",
+  "clear_no_match_cl",
+}
+
+for fn_name, fn in pairs(core) do
+  if vim.tbl_contains(fns_to_wrap, fn_name) then
+    M[fn_name] = valid_buftype_callback(fn)
+  end
+end
+
+return M


### PR DESCRIPTION
This fixes:

- #1
- A part of #2. For *Neogit* with *diffview* integration enabled, this errors out when quitting a *diffview* diff.